### PR TITLE
[BNB-52] Preventing error -1125

### DIFF
--- a/src/BinanceStreams.js
+++ b/src/BinanceStreams.js
@@ -195,6 +195,10 @@ class BinanceStreams {
             const userStreamCache = this.getUserDataStream(userStreamID);
 
             if (Object.keys(closed).length) {
+                if (closed.code === -1125) {
+                    return closed;
+                }
+
                 throw closed;
             }
 


### PR DESCRIPTION
## [BNB-52] Description
Silencing the error -1125 when the listenKey doesn't exist

[BNB-52]: https://feliperamosdev.atlassian.net/browse/BNB-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ