### PR TITLE
[BNB-74] Remove await for server time on URL parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# binance-sync v0.2.9 BETA
+# binance-sync v0.2.10 BETA
 It's a service module to interact with Binance
 
 ## Binance API - Endpoints

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance-sync",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "It's a service module to interact with Binance",
   "main": "index.js",
   "scripts": {

--- a/src/BinanceAJAX.js
+++ b/src/BinanceAJAX.js
@@ -81,14 +81,14 @@ class BinanceAJAX extends Axios {
      * @returns {Promise<string>} The parsed URL.
      * @throws {Error} If there is an error during parsing.
      */
-    async parseURL(endpoint, params) {
+    parseURL(endpoint, params) {
         const queryString = new URLSearchParams('');
 
         try {
-            const serverTime = await this.getServerTime();
+            const serverTime = new Date(new Date().toUTCString()).getTime();
 
             queryString.set('recvWindow', 60000);
-            queryString.set('timestamp', serverTime);
+            queryString.set('timestamp', serverTime - 3000);
 
             Object.keys(Object(params)).map(key => params[key] && queryString.set(key, params[key]));
 
@@ -116,7 +116,7 @@ class BinanceAJAX extends Axios {
      */
     async GET(endpoint, params) {
         try {
-            const url = await this.parseURL(endpoint, params);
+            const url = this.parseURL(endpoint, params);
             const result = await this.get(url);
 
             return JSON.parse(Object(result.data));
@@ -135,7 +135,7 @@ class BinanceAJAX extends Axios {
      */
     async POST(endpoint, params) {
         try {
-            const url = await this.parseURL(endpoint, params);
+            const url = this.parseURL(endpoint, params);
             const result = await this.post(url);
 
             return JSON.parse(Object(result.data));
@@ -154,7 +154,7 @@ class BinanceAJAX extends Axios {
      */
     async PUT(endpoint, params) {
         try {
-            const url = await this.parseURL(endpoint, params);
+            const url = this.parseURL(endpoint, params);
             const result = await this.put(url);
 
             return JSON.parse(Object(result.data));
@@ -173,7 +173,7 @@ class BinanceAJAX extends Axios {
      */
     async DELETE(endpoint, params) {
         try {
-            const url = await this.parseURL(endpoint, params);
+            const url = this.parseURL(endpoint, params);
             const result = await this.delete(url);
 
             return JSON.parse(Object(result.data));


### PR DESCRIPTION
## [BNB-74] Description
Removed the approach that was taking the server time by doing a request to Binance. Now we're getting it static.

[BNB-74]: https://feliperamosdev.atlassian.net/browse/BNB-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ