### PR TITLE
[BNB-77] Update futures stream URL and bump version

### DIFF
--- a/configs.json
+++ b/configs.json
@@ -1,7 +1,7 @@
 {
     "URLS": {
         "futuresBase": "https://fapi.binance.com",
-        "futuresBaseStream": "wss://fstream.binance.com/ws"
+        "futuresBaseStream": "wss://fstream.binancefuture.com/ws"
     },
     "connections": {
         "streamPingInterval": 2700000,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance-sync",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "It's a service module to interact with Binance",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request makes a minor update to the project configuration. The main change is updating the Binance Futures WebSocket base URL, and incrementing the package version to reflect this update.

Configuration update:

* Changed the `futuresBaseStream` URL in `configs.json` to use `wss://fstream.binancefuture.com/ws` instead of `wss://fstream.binance.com/ws`, likely to point to an updated or correct endpoint.

Versioning:

* Bumped the package version in `package.json` from `0.2.12` to `0.2.13` to reflect the configuration change.